### PR TITLE
show correct color of the beam

### DIFF
--- a/photon_beam/shaders/raytrace.rahit
+++ b/photon_beam/shaders/raytrace.rahit
@@ -55,7 +55,7 @@ void main()
 
     if(pcRay.showDirectColor == 1)
     {
-        prd.hitValue = beam.lightColor  / max(max(pcRay.sourceLight.x, pcRay.sourceLight.y), pcRay.sourceLight.z);
+        prd.hitValue = beam.lightColor  / max(max(beam.lightColor.x, beam.lightColor.y), beam.lightColor.z);
         return;
     }    
 


### PR DESCRIPTION
Show beam hue not relative to the original light source power.
Do not show beam hue relative to the original light source power.